### PR TITLE
feat(linux-daemon): periodic heartbeat to provisioning

### DIFF
--- a/daemons/linux/index.js
+++ b/daemons/linux/index.js
@@ -2,6 +2,7 @@
 import HTTPServer from './src/Networking/HTTPServer.js'
 import { daemonToken, daemonTokenPath } from './src/Routing/DaemonAuth.js'
 import { startDaemonUpdater } from './src/Updater/DaemonUpdater.js'
+import { startRemoteHeartbeat } from './src/Provisioning/RemoteHeartbeat.js'
 
 const host = process.env.CLOUDE_HOST || '0.0.0.0'
 const port = Number.parseInt(process.env.CLOUDE_PORT || '8765', 10)
@@ -10,3 +11,4 @@ daemonToken()
 new HTTPServer({ host, port }).start()
 console.log(`DaemonAuth: token loaded from ${daemonTokenPath()}`)
 startDaemonUpdater()
+startRemoteHeartbeat()

--- a/daemons/linux/src/Provisioning/RemoteHeartbeat.js
+++ b/daemons/linux/src/Provisioning/RemoteHeartbeat.js
@@ -1,0 +1,23 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { loadOrCreateIdentity } from './Identity.js'
+import { putHeartbeat } from './RemoteTunnelClient.js'
+
+const HEARTBEAT_INTERVAL_MS = 60 * 1000
+
+export function startRemoteHeartbeat() {
+  const dataDirectory = process.env.CLOUDE_DATA || path.join(os.homedir(), '.cloude-agent')
+  if (fs.existsSync(path.join(dataDirectory, 'tunnel.json'))) {
+    const identity = loadOrCreateIdentity()
+    console.log(`[RemoteHeartbeat] starting, every ${HEARTBEAT_INTERVAL_MS / 1000}s`)
+    const beat = () =>
+      putHeartbeat(identity)
+        .then((ok) => {
+          if (!ok) console.log('[RemoteHeartbeat] heartbeat rejected')
+        })
+        .catch((e) => console.log(`[RemoteHeartbeat] heartbeat failed: ${e.message}`))
+    beat()
+    setInterval(beat, HEARTBEAT_INTERVAL_MS)
+  }
+}

--- a/daemons/linux/src/Provisioning/RemoteTunnelClient.js
+++ b/daemons/linux/src/Provisioning/RemoteTunnelClient.js
@@ -26,3 +26,14 @@ export async function putTunnel(identity) {
   }
   return null
 }
+
+export async function putHeartbeat(identity) {
+  const response = await fetch(`${provisioningURL}/macs/${identity.installationId}/heartbeat`, {
+    method: 'PUT',
+    headers: {
+      'X-Mac-Secret': identity.secret,
+      'User-Agent': 'CloudeLinuxDaemon/1',
+    },
+  })
+  return response.ok
+}


### PR DESCRIPTION
The linux daemon never sent heartbeats, so provisioning last_seen for any linux endpoint froze at provision time (medina looked stale despite daily use). Adds a 60s heartbeat loop wired in index.js, gated on tunnel.json, calling the existing PUT /macs/{id}/heartbeat endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)